### PR TITLE
Add a new JSON matcher on Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ item 0: User {
 [![Javadocs](http://www.javadoc.io/badge/com.spotify/hamcrest-jackson.svg?color=blue)](http://www.javadoc.io/doc/com.spotify/hamcrest-jackson)
 
 Similar to the POJO matchers, the JSON matchers let you describe a
-JSON structure and match a string or against it.
+JSON structure and match against it.
+
+The match can be on a `String` or a jackson `JsonNode`. 
 
 ```java
 // You can match a String

--- a/README.md
+++ b/README.md
@@ -107,9 +107,23 @@ item 0: User {
 [![Javadocs](http://www.javadoc.io/badge/com.spotify/hamcrest-jackson.svg?color=blue)](http://www.javadoc.io/doc/com.spotify/hamcrest-jackson)
 
 Similar to the POJO matchers, the JSON matchers let you describe a
-JSON structure and match against it.
+JSON structure and match a string or against it.
 
 ```java
+// You can match a String
+String jsonString = "{" +
+ "  \"foo\": 1," +
+ "  \"bar\": true," +
+ "  \"baz\": {" +
+ "    \"foo\": true" +
+ "  }" +
+ "}"
+
+// You can match a Json String directly
+assertThat("{}", isJsonStringMatching(jsonObject()));
+
+// Or match a Jackson node
+JsonNode json = new ObjectMapper().readTree(jsonString);
 assertThat(json, is(
      jsonObject()
          .where("foo", is(jsonInt(1)))

--- a/jackson/src/main/java/com/spotify/hamcrest/jackson/IsJsonStringMatching.java
+++ b/jackson/src/main/java/com/spotify/hamcrest/jackson/IsJsonStringMatching.java
@@ -1,0 +1,89 @@
+/*-
+ * -\-\-
+ * hamcrest-jackson
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.jackson;
+
+import static org.hamcrest.Condition.matched;
+import static org.hamcrest.Condition.notMatched;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.hamcrest.Condition;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * Matcher for matching Json strings
+ *
+ * <p>This is useful as an entry point to matching larger structures without needing
+ * to use Jackson explicitly.
+ *
+ * <pre>
+ *   <code>
+ *     String myJson = "{\"key\": 1234}";
+ *     assertThat(myJson, isJsonStringMatching(jsonObject().where("key", jsonInt(1234)));
+ *   </code>
+ * </pre>
+ */
+public final class IsJsonStringMatching extends TypeSafeDiagnosingMatcher<String> {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public static Matcher<String> isJsonStringMatching(final Matcher<JsonNode> matcher) {
+    return new IsJsonStringMatching(matcher);
+  }
+
+  private final Matcher<JsonNode> matcher;
+
+  private IsJsonStringMatching(final Matcher<JsonNode> matcher) {
+    this.matcher = matcher;
+  }
+
+  @Override
+  protected boolean matchesSafely(final String string, final Description description) {
+    return parseJsonNode(string, description)
+        .matching(matcher);
+  }
+
+  private Condition<JsonNode> parseJsonNode(final String string,
+                                            final Description mismatchDescription) {
+    if (string == null) {
+      mismatchDescription.appendText(" but JSON string was null");
+      return notMatched();
+    }
+
+    try {
+      final JsonNode jsonNode = MAPPER.readTree(string);
+      return matched(jsonNode, mismatchDescription);
+    } catch (IOException e) {
+      mismatchDescription.appendText(" but the string was not valid JSON ")
+          .appendValue(e.getMessage());
+      return notMatched();
+    }
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    description.appendText("A JSON string that matches ")
+        .appendDescriptionOf(matcher);
+  }
+}

--- a/jackson/src/test/java/com/spotify/hamcrest/jackson/IsJsonStringMatchingTest.java
+++ b/jackson/src/test/java/com/spotify/hamcrest/jackson/IsJsonStringMatchingTest.java
@@ -1,0 +1,94 @@
+/*-
+ * -\-\-
+ * hamcrest-jackson
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.jackson;
+
+import static com.spotify.hamcrest.jackson.IsJsonNumber.jsonInt;
+import static com.spotify.hamcrest.jackson.IsJsonObject.jsonObject;
+import static com.spotify.hamcrest.jackson.IsJsonStringMatching.isJsonStringMatching;
+import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+public class IsJsonStringMatchingTest {
+
+  @Test
+  public void invalidJsonDoesNotMatch() throws Exception {
+    final Matcher<String> sut = isJsonStringMatching(any(JsonNode.class));
+
+    assertThat("{", not(sut));
+  }
+
+  @Test
+  public void testDescription() throws Exception {
+    final Matcher<String> sut = isJsonStringMatching(jsonObject());
+
+    final Description description = new StringDescription();
+    sut.describeTo(description);
+
+    assertThat(description.toString(), is(
+        "A JSON string that matches {\n"
+        + "}")
+    );
+  }
+
+  @Test
+  public void testNull() throws Exception {
+    final Matcher<String> sut = isJsonStringMatching(any(JsonNode.class));
+
+    assertThat(null, not(sut));
+  }
+
+  @Test
+  public void validJsonMatchesAnything() throws Exception {
+    final Matcher<String> sut = isJsonStringMatching(any(JsonNode.class));
+
+    assertThat("{}", sut);
+  }
+
+  @Test
+  public void validJsonMatchesAnObject() throws Exception {
+    assertThat("{}", isJsonStringMatching(jsonObject()));
+  }
+
+  @Test
+  public void testJsonInt() throws Exception {
+    assertThat("123", isJsonStringMatching(jsonInt(123)));
+  }
+
+  @Test
+  public void invalidJsonDescription() throws Exception {
+    final Matcher<String> sut = isJsonStringMatching(any(JsonNode.class));
+
+    final Description description = new StringDescription();
+    sut.describeMismatch("{", description);
+
+    assertThat(description.toString(), containsString("but the string was not valid JSON"));
+  }
+
+}


### PR DESCRIPTION
This allow Jackson to be hidden as an implementation detail as matching can start on a string.
This also handles invalid JSON and nulls in a graceful way.

For example,

```java
String myJson = "{\"key\": 1234}";
assertThat(myJson, isJsonStringMatching(jsonObject().where("key", jsonInt(1234)));
```