### PR TITLE
Clean up classpath and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 !.git*
 target/
+.idea
+*.iml
+*~

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
I noticed I had different versions of some classes on the classpath because junit pulls in an older version of hamcrest-core than this library.