### PR TITLE
Adding support for type-safe lambdas.

### DIFF
--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
@@ -86,26 +86,23 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
       return false;
     }
 
-    final Map<String, Consumer<Description>> mismatches = new LinkedHashMap<>();
+    final Map<Function<A, ?>, Consumer<Description>> mismatches = new LinkedHashMap<>();
 
     methodMatchers.forEach((valueSupplier, matcher) -> {
       try {
         Object value = valueSupplier.apply(item);
         if (!matcher.matches(value)) {
-          mismatches.put(valueSupplier.toString(), d -> matcher.describeMismatch(value, d));
+          mismatches.put(valueSupplier, d -> matcher.describeMismatch(value, d));
         }
       } catch (MethodValueSupplierException mvsex) {
-        mismatches.put(valueSupplier.toString(), d -> d.appendText(mvsex.getDescription()));
+        mismatches.put(valueSupplier, d -> d.appendText(mvsex.getDescription()));
       }
     });
 
     if (!mismatches.isEmpty()) {
       mismatchDescription.appendText(cls.getSimpleName()).appendText(" ");
       DescriptionUtils.describeNestedMismatches(
-          methodMatchers.keySet()
-              .stream()
-              .map(Object::toString)
-              .collect(Collectors.toCollection(LinkedHashSet::new)),
+          methodMatchers.keySet(),
           mismatchDescription,
           mismatches,
           IsPojo::describeMethod);

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
@@ -20,22 +20,17 @@
 
 package com.spotify.hamcrest.pojo;
 
+import static com.spotify.hamcrest.pojo.LambdaUtils.extractLambdaName;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.hamcrest.util.DescriptionUtils;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -51,8 +46,8 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
 
   private IsPojo(final Class<A> cls,
                  final ImmutableMap<Function<A, ?>, Matcher<?>> methodMatchers) {
-    this.cls = Objects.requireNonNull(cls);
-    this.methodMatchers = Objects.requireNonNull(methodMatchers);
+    this.cls = requireNonNull(cls);
+    this.methodMatchers = requireNonNull(methodMatchers);
   }
 
   public static <A> IsPojo<A> pojo(Class<A> cls) {
@@ -82,42 +77,6 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
                             .putAll(methodMatchers)
                             .put(valueSupplier, valueMatcher)
                             .build());
-  }
-
-  /**
-   * Method uses serialization trick to extract information about lambda,
-   * to give understandable name in case of mismatch.
-   * @param lambda lambda to extract the name from
-   * @return string describing class and method from which lambda was created,
-   *     or simple {@code toString()} if that fails.
-   */
-  private String extractLambdaName(Object lambda) {
-    try {
-      // serializing lambda:
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      ObjectOutputStream oos = new ObjectOutputStream(baos);
-      oos.writeObject(lambda);
-      oos.flush();
-      // replace class name to avoid special handling,
-      // class name has to be identical, otherwise UTF8 serialization handling
-      // will have to be changed too:
-      byte[] hacked = new String(baos.toByteArray(), StandardCharsets.ISO_8859_1)
-          .replace("java.lang.invoke.SerializedLambda",
-                   "com.spotify.hamcrest.pojo.Lambda1")
-          .getBytes(StandardCharsets.ISO_8859_1);
-
-      final Lambda1 deserializedLambda = (Lambda1) new ObjectInputStream(
-          new ByteArrayInputStream(hacked)).readObject();
-      if (deserializedLambda.implClass != null && deserializedLambda.implMethodName != null) {
-        return deserializedLambda.implClass
-                   .substring(deserializedLambda.implClass.lastIndexOf('/') + 1)
-               + "::"
-               + deserializedLambda.implMethodName;
-      }
-    } catch (Exception ignore) {
-      // nop
-    }
-    return lambda.toString();
   }
 
   @Override
@@ -182,87 +141,6 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
         .appendText(
             Joiner.on("\n  ").join(Splitter.on('\n').split(innerDescription.toString())))
         .appendText("\n");
-  }
-
-  private static class MethodValueSupplier<A> implements Function<A, Object> {
-
-    private final String methodName;
-
-    public MethodValueSupplier(String methodName) {
-      this.methodName = methodName;
-    }
-
-    @Override
-    public Object apply(A item) {
-      final Object returnValue;
-      try {
-        returnValue = item.getClass().getMethod(methodName).invoke(item);
-        return returnValue;
-      } catch (IllegalAccessException e) {
-        // This only happens if the method has been removed from the class after the code was
-        // compiled, so very unlikely...
-        throw new MethodValueSupplierException(methodName, "was not accessible");
-      } catch (InvocationTargetException e) {
-        final Throwable cause = e.getCause();
-        throw new MethodValueSupplierException(methodName, "threw an exception: "
-                                                           + cause.getClass().getCanonicalName()
-                                                           + ": "
-                                                           + cause.getMessage());
-      } catch (NoSuchMethodException e) {
-        throw new MethodValueSupplierException(methodName, "did not exist");
-      }
-    }
-
-    @Override
-    public String toString() {
-      return methodName;
-    }
-  }
-
-  private static class NamedLambdaValueSupplier<A> implements Function<A, Object> {
-
-    private final String lambdaName;
-    private final Function<A, ?> delegateFunction;
-
-    public NamedLambdaValueSupplier(String lambdaName, Function<A, ?> delegateFunction) {
-      this.lambdaName = lambdaName;
-      this.delegateFunction = delegateFunction;
-    }
-
-    @Override
-    public Object apply(A input) {
-      return delegateFunction.apply(input);
-    }
-
-    @Override
-    public String toString() {
-      return lambdaName;
-    }
-  }
-
-  private static class MethodValueSupplierException extends RuntimeException {
-
-    private final String methodName;
-    private final String description;
-
-    public MethodValueSupplierException(String methodName, String description) {
-      this.methodName = methodName;
-      this.description = description;
-    }
-
-    public String getMethodName() {
-      return methodName;
-    }
-
-    public String getDescription() {
-      return description;
-    }
-  }
-
-  /**
-   * Adds serialization marker to {@code Function}.
-   */
-  public interface ValueProvider<A, T> extends Function<A, T>, Serializable {
   }
 
 }

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
@@ -2,7 +2,7 @@
  * -\-\-
  * hamcrest-pojo
  * --
- * Copyright (C) 2016 Spotify AB
+ * Copyright (C) 2017 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,20 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.hamcrest.util.DescriptionUtils;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
@@ -38,9 +47,10 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
 
   private final Class<A> cls;
-  private final ImmutableMap<String, Matcher<?>> methodMatchers;
+  private final ImmutableMap<Function<A, ?>, Matcher<?>> methodMatchers;
 
-  private IsPojo(final Class<A> cls, final ImmutableMap<String, Matcher<?>> methodMatchers) {
+  private IsPojo(final Class<A> cls,
+                 final ImmutableMap<Function<A, ?>, Matcher<?>> methodMatchers) {
     this.cls = Objects.requireNonNull(cls);
     this.methodMatchers = Objects.requireNonNull(methodMatchers);
   }
@@ -50,18 +60,64 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
   }
 
   public IsPojo<A> where(String methodName, Matcher<?> returnValueMatcher) {
-    final ImmutableMap<String, Matcher<?>> newMethodMatchers =
-        ImmutableMap.<String, Matcher<?>>builder()
-            .putAll(methodMatchers)
-            .put(methodName, returnValueMatcher)
-            .build();
+    return whereWithoutTypeSafety(new MethodValueSupplier<>(methodName), returnValueMatcher);
+  }
 
-    return new IsPojo<>(cls, newMethodMatchers);
+  public <T> IsPojo<A> where(ValueProvider<A, T> valueProvider, Matcher<T> valueMatcher) {
+    return whereWithoutTypeSafety(
+        new NamedLambdaValueSupplier<>(
+            extractLambdaName(valueProvider),
+            valueProvider),
+        valueMatcher);
   }
 
   public IsPojo<A> withProperty(String property, Matcher<?> valueMatcher) {
     return where("get" + CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, property),
                  valueMatcher);
+  }
+
+  private IsPojo<A> whereWithoutTypeSafety(Function<A, ?> valueSupplier, Matcher<?> valueMatcher) {
+    return new IsPojo<>(cls,
+                        ImmutableMap.<Function<A, ?>, Matcher<?>>builder()
+                            .putAll(methodMatchers)
+                            .put(valueSupplier, valueMatcher)
+                            .build());
+  }
+
+  /**
+   * Method uses serialization trick to extract information about lambda,
+   * to give understandable name in case of mismatch.
+   * @param lambda lambda to extract the name from
+   * @return string describing class and method from which lambda was created,
+   *     or simple {@code toString()} if that fails.
+   */
+  private String extractLambdaName(Object lambda) {
+    try {
+      // serializing lambda:
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ObjectOutputStream oos = new ObjectOutputStream(baos);
+      oos.writeObject(lambda);
+      oos.flush();
+      // replace class name to avoid special handling,
+      // class name has to be identical, otherwise UTF8 serialization handling
+      // will have to be changed too:
+      byte[] hacked = new String(baos.toByteArray(), StandardCharsets.ISO_8859_1)
+          .replace("java.lang.invoke.SerializedLambda",
+                   "com.spotify.hamcrest.pojo.Lambda1")
+          .getBytes(StandardCharsets.ISO_8859_1);
+
+      final Lambda1 deserializedLambda = (Lambda1) new ObjectInputStream(
+          new ByteArrayInputStream(hacked)).readObject();
+      if (deserializedLambda.implClass != null && deserializedLambda.implMethodName != null) {
+        return deserializedLambda.implClass
+                   .substring(deserializedLambda.implClass.lastIndexOf('/') + 1)
+               + "::"
+               + deserializedLambda.implMethodName;
+      }
+    } catch (Exception ignore) {
+      // nop
+    }
+    return lambda.toString();
   }
 
   @Override
@@ -73,36 +129,24 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
 
     final Map<String, Consumer<Description>> mismatches = new LinkedHashMap<>();
 
-    for (Map.Entry<String, Matcher<?>> methodMatcher : methodMatchers.entrySet()) {
-      final String methodName = methodMatcher.getKey();
-      final Matcher<?> matcher = methodMatcher.getValue();
-
-      final Object returnValue;
+    methodMatchers.forEach((valueSupplier, matcher) -> {
       try {
-        returnValue = cls.getMethod(methodName).invoke(item);
-        if (!matcher.matches(returnValue)) {
-          mismatches.put(methodName, d -> matcher.describeMismatch(returnValue, d));
+        Object value = valueSupplier.apply(item);
+        if (!matcher.matches(value)) {
+          mismatches.put(valueSupplier.toString(), d -> matcher.describeMismatch(value, d));
         }
-      } catch (IllegalAccessException e) {
-        // This only happens if the method has been removed from the class after the code was
-        // compiled, so very unlikely...
-        mismatches.put(methodName, d -> d.appendText("was not accessible"));
-      } catch (InvocationTargetException e) {
-        final Throwable cause = e.getCause();
-        mismatches.put(methodName,
-            d -> d.appendText("threw an exception: ")
-                .appendText(cause.getClass().getCanonicalName())
-                .appendText(": ")
-                .appendText(cause.getMessage()));
-      } catch (NoSuchMethodException e) {
-        mismatches.put(methodName, d -> d.appendText("did not exist"));
+      } catch (MethodValueSupplierException mvsex) {
+        mismatches.put(valueSupplier.toString(), d -> d.appendText(mvsex.getDescription()));
       }
-    }
+    });
 
     if (!mismatches.isEmpty()) {
       mismatchDescription.appendText(cls.getSimpleName()).appendText(" ");
       DescriptionUtils.describeNestedMismatches(
-          methodMatchers.keySet(),
+          methodMatchers.keySet()
+              .stream()
+              .map(Object::toString)
+              .collect(Collectors.toCollection(LinkedHashSet::new)),
           mismatchDescription,
           mismatches,
           IsPojo::describeMethod);
@@ -116,16 +160,15 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
   public void describeTo(Description description) {
     description.appendText(cls.getSimpleName()).appendText(" {\n");
 
-    for (Map.Entry<String, Matcher<?>> methodMatcher : methodMatchers.entrySet()) {
-      final String methodName = methodMatcher.getKey();
-      final Matcher<?> matcher = methodMatcher.getValue();
+    methodMatchers.forEach((valueSupplier, matcher) -> {
+      final String methodName = valueSupplier.toString();
       description.appendText("  ").appendText(methodName).appendText("(): ");
 
       Description innerDescription = new StringDescription();
       matcher.describeTo(innerDescription);
 
       indentDescription(description, innerDescription);
-    }
+    });
     description.appendText("}");
   }
 
@@ -140,4 +183,86 @@ public class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
             Joiner.on("\n  ").join(Splitter.on('\n').split(innerDescription.toString())))
         .appendText("\n");
   }
+
+  private static class MethodValueSupplier<A> implements Function<A, Object> {
+
+    private final String methodName;
+
+    public MethodValueSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @Override
+    public Object apply(A item) {
+      final Object returnValue;
+      try {
+        returnValue = item.getClass().getMethod(methodName).invoke(item);
+        return returnValue;
+      } catch (IllegalAccessException e) {
+        // This only happens if the method has been removed from the class after the code was
+        // compiled, so very unlikely...
+        throw new MethodValueSupplierException(methodName, "was not accessible");
+      } catch (InvocationTargetException e) {
+        final Throwable cause = e.getCause();
+        throw new MethodValueSupplierException(methodName, "threw an exception: "
+                                                           + cause.getClass().getCanonicalName()
+                                                           + ": "
+                                                           + cause.getMessage());
+      } catch (NoSuchMethodException e) {
+        throw new MethodValueSupplierException(methodName, "did not exist");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return methodName;
+    }
+  }
+
+  private static class NamedLambdaValueSupplier<A> implements Function<A, Object> {
+
+    private final String lambdaName;
+    private final Function<A, ?> delegateFunction;
+
+    public NamedLambdaValueSupplier(String lambdaName, Function<A, ?> delegateFunction) {
+      this.lambdaName = lambdaName;
+      this.delegateFunction = delegateFunction;
+    }
+
+    @Override
+    public Object apply(A input) {
+      return delegateFunction.apply(input);
+    }
+
+    @Override
+    public String toString() {
+      return lambdaName;
+    }
+  }
+
+  private static class MethodValueSupplierException extends RuntimeException {
+
+    private final String methodName;
+    private final String description;
+
+    public MethodValueSupplierException(String methodName, String description) {
+      this.methodName = methodName;
+      this.description = description;
+    }
+
+    public String getMethodName() {
+      return methodName;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+  }
+
+  /**
+   * Adds serialization marker to {@code Function}.
+   */
+  public interface ValueProvider<A, T> extends Function<A, T>, Serializable {
+  }
+
 }

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/Lambda1.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/Lambda1.java
@@ -1,0 +1,44 @@
+/*-
+ * -\-\-
+ * hamcrest-pojo
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.pojo;
+
+import java.io.Serializable;
+
+/**
+ * Class is a copy of {@code java.lang.invoke.SerializedLambda}
+ * to deserialize lambda into values instead of back to lambda.<br/>
+ * Full class name has to be identical length to {@code java.lang.invoke.SerializedLambda}.
+ *
+ * @see java.lang.invoke.SerializedLambda
+ */
+class Lambda1 implements Serializable {
+  private static final long serialVersionUID = 8025925345765570181L;
+  Class<?> capturingClass;
+  String functionalInterfaceClass;
+  String functionalInterfaceMethodName;
+  String functionalInterfaceMethodSignature;
+  String implClass;
+  String implMethodName;
+  String implMethodSignature;
+  int implMethodKind;
+  String instantiatedMethodType;
+  Object[] capturedArgs;
+}

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/LambdaUtils.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/LambdaUtils.java
@@ -1,0 +1,68 @@
+/*-
+ * -\-\-
+ * hamcrest-pojo
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.pojo;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+
+final class LambdaUtils {
+  /**
+   * Method uses serialization trick to extract information about lambda,
+   * to give understandable name in case of mismatch.
+   * @param lambda lambda to extract the name from
+   * @return string describing class and method from which lambda was created,
+   *     or simple {@code toString()} if that fails.
+   */
+  public static String extractLambdaName(Object lambda) {
+    requireNonNull(lambda);
+    try {
+      SerializedLambda serializedLambda = toSerializedLambda(lambda);
+      return serializedLambda.getImplClass()
+                 .substring(serializedLambda.getImplClass().lastIndexOf('/') + 1)
+             + "::"
+             + serializedLambda.getImplMethodName();
+    } catch (Exception ignore) {
+      ignore.printStackTrace();
+      // nop
+    }
+    return lambda.toString();
+  }
+
+  private static SerializedLambda toSerializedLambda(Object lambda) throws Exception {
+    Method writeReplace = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+      @Override
+      public Method run() throws Exception {
+        Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+        method.setAccessible(true);
+        return method;
+      }
+    });
+    SerializedLambda serializedLambda = (SerializedLambda) writeReplace.invoke(lambda);
+    return serializedLambda;
+  }
+
+  private LambdaUtils() {
+  }
+}

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/LambdaUtils.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/LambdaUtils.java
@@ -35,7 +35,7 @@ final class LambdaUtils {
    * @return string describing class and method from which lambda was created,
    *     or simple {@code toString()} if that fails.
    */
-  public static String extractLambdaName(Object lambda) {
+  public static <A, T> String extractLambdaName(ValueProvider<A, T> lambda) {
     requireNonNull(lambda);
     try {
       SerializedLambda serializedLambda = toSerializedLambda(lambda);

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/MethodValueSupplier.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/MethodValueSupplier.java
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * hamcrest-pojo
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.pojo;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Function;
+
+class MethodValueSupplier<A> implements Function<A, Object> {
+
+  private final String methodName;
+
+  public MethodValueSupplier(String methodName) {
+    this.methodName = methodName;
+  }
+
+  @Override
+  public Object apply(A item) {
+    final Object returnValue;
+    try {
+      returnValue = item.getClass().getMethod(methodName).invoke(item);
+      return returnValue;
+    } catch (IllegalAccessException e) {
+      // This only happens if the method has been removed from the class after the code was
+      // compiled, so very unlikely...
+      throw new MethodValueSupplierException(methodName, "was not accessible");
+    } catch (InvocationTargetException e) {
+      final Throwable cause = e.getCause();
+      throw new MethodValueSupplierException(methodName, "threw an exception: "
+                                                         + cause.getClass().getCanonicalName()
+                                                         + ": "
+                                                         + cause.getMessage());
+    } catch (NoSuchMethodException e) {
+      throw new MethodValueSupplierException(methodName, "did not exist");
+    }
+  }
+
+  @Override
+  public String toString() {
+    return methodName;
+  }
+}

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/MethodValueSupplierException.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/MethodValueSupplierException.java
@@ -1,0 +1,40 @@
+/*-
+ * -\-\-
+ * hamcrest-pojo
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.pojo;
+
+class MethodValueSupplierException extends RuntimeException {
+
+  private final String methodName;
+  private final String description;
+
+  public MethodValueSupplierException(String methodName, String description) {
+    this.methodName = methodName;
+    this.description = description;
+  }
+
+  public String getMethodName() {
+    return methodName;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/NamedLambdaValueSupplier.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/NamedLambdaValueSupplier.java
@@ -1,0 +1,44 @@
+/*-
+ * -\-\-
+ * hamcrest-pojo
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hamcrest.pojo;
+
+import java.util.function.Function;
+
+class NamedLambdaValueSupplier<A> implements Function<A, Object> {
+
+  private final String lambdaName;
+  private final Function<A, ?> delegateFunction;
+
+  public NamedLambdaValueSupplier(String lambdaName, Function<A, ?> delegateFunction) {
+    this.lambdaName = lambdaName;
+    this.delegateFunction = delegateFunction;
+  }
+
+  @Override
+  public Object apply(A input) {
+    return delegateFunction.apply(input);
+  }
+
+  @Override
+  public String toString() {
+    return lambdaName;
+  }
+}

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/ValueProvider.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/ValueProvider.java
@@ -21,24 +21,10 @@
 package com.spotify.hamcrest.pojo;
 
 import java.io.Serializable;
+import java.util.function.Function;
 
 /**
- * Class is a copy of {@code java.lang.invoke.SerializedLambda}
- * to deserialize lambda into values instead of back to lambda.<br/>
- * Full class name has to be identical length to {@code java.lang.invoke.SerializedLambda}.
- *
- * @see java.lang.invoke.SerializedLambda
+ * Adds serialization marker to {@code Function}.
  */
-class Lambda1 implements Serializable {
-  private static final long serialVersionUID = 8025925345765570181L;
-  Class<?> capturingClass;
-  String functionalInterfaceClass;
-  String functionalInterfaceMethodName;
-  String functionalInterfaceMethodSignature;
-  String implClass;
-  String implMethodName;
-  String implMethodSignature;
-  int implMethodKind;
-  String instantiatedMethodType;
-  Object[] capturedArgs;
+public interface ValueProvider<A, T> extends Function<A, T>, Serializable {
 }

--- a/pojo/src/test/java/com/spotify/hamcrest/pojo/IsPojoTest.java
+++ b/pojo/src/test/java/com/spotify/hamcrest/pojo/IsPojoTest.java
@@ -22,6 +22,7 @@ package com.spotify.hamcrest.pojo;
 
 import static com.spotify.hamcrest.pojo.IsPojo.pojo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsAnything.anything;
 
@@ -220,6 +221,21 @@ public class IsPojoTest {
         + "  SomeClass::baz(): SomeClass {\n"
         + "    SomeClass::foo(): was <42>\n"
         + "  }\n"
+        + "}"
+    ));
+  }
+
+  @Test
+  public void testMultipleIdenticalMatches() throws Exception {
+    final IsPojo<SomeClass> sut = pojo(SomeClass.class)
+        .where(SomeClass::getBar, is("bar1"))
+        .where(SomeClass::getBar, instanceOf(StringBuffer.class));
+    final StringDescription description = new StringDescription();
+    sut.describeMismatch(new SomeClass(), description);
+    assertThat(description.toString(), is(
+        "SomeClass {\n"
+        + "  SomeClass::getBar(): was \"bar\"\n"
+        + "  SomeClass::getBar(): \"bar\" is a java.lang.String\n"
         + "}"
     ));
   }

--- a/pojo/src/test/java/com/spotify/hamcrest/pojo/IsPojoTest.java
+++ b/pojo/src/test/java/com/spotify/hamcrest/pojo/IsPojoTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsAnything.anything;
 
 import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 import org.hamcrest.StringDescription;
 import org.junit.Rule;

--- a/util/src/main/java/com/spotify/hamcrest/util/DescriptionUtils.java
+++ b/util/src/main/java/com/spotify/hamcrest/util/DescriptionUtils.java
@@ -114,9 +114,9 @@ public final class DescriptionUtils {
   }
 
   private static <T> void describeMismatchForKey(T key,
-                                             Description mismatchDescription,
-                                             BiConsumer<String, Description> describeKey,
-                                             Consumer<Description> innerAction) {
+                                                 Description mismatchDescription,
+                                                 BiConsumer<String, Description> describeKey,
+                                                 Consumer<Description> innerAction) {
 
     mismatchDescription.appendText("  ");
     describeKey.accept(String.valueOf(key), mismatchDescription);

--- a/util/src/main/java/com/spotify/hamcrest/util/DescriptionUtils.java
+++ b/util/src/main/java/com/spotify/hamcrest/util/DescriptionUtils.java
@@ -77,18 +77,18 @@ public final class DescriptionUtils {
    *                       which will write the describe the mismatch for that key
    * @param describeKey A {@link BiConsumer} used to describe the key
    */
-  public static void describeNestedMismatches(
-      Set<String> allKeys,
+  public static <T> void describeNestedMismatches(
+      Set<T> allKeys,
       Description mismatchDescription,
-      Map<String, Consumer<Description>> mismatchedKeys,
+      Map<T, Consumer<Description>> mismatchedKeys,
       BiConsumer<String, Description> describeKey) {
     checkArgument(!mismatchedKeys.isEmpty(), "mismatchKeys must not be empty");
-    String previousMismatchKey = null;
-    String previousKey = null;
+    T previousMismatchKey = null;
+    T previousKey = null;
 
     mismatchDescription.appendText("{\n");
 
-    for (String key : allKeys) {
+    for (T key : allKeys) {
       if (mismatchedKeys.containsKey(key)) {
         // If this is not the first key and the previous key was not a mismatch then add ellipsis
         if (previousKey != null && !Objects.equals(previousMismatchKey, previousKey)) {
@@ -113,13 +113,13 @@ public final class DescriptionUtils {
     mismatchDescription.appendText("}");
   }
 
-  private static void describeMismatchForKey(String key,
+  private static <T> void describeMismatchForKey(T key,
                                              Description mismatchDescription,
                                              BiConsumer<String, Description> describeKey,
                                              Consumer<Description> innerAction) {
 
     mismatchDescription.appendText("  ");
-    describeKey.accept(key, mismatchDescription);
+    describeKey.accept(String.valueOf(key), mismatchDescription);
     mismatchDescription.appendText(": ");
 
     final Description innerDescription = new StringDescription();


### PR DESCRIPTION
@davidxia @mattnworb @dflemstr @eshrubs 

All of this it to add support for following structure:
```
    final IsPojo<SomeClass> sut = pojo(SomeClass.class)
        .where(SomeClass::foo, is(42))
        .where(SomeClass::baz, is(
            pojo(SomeClass.class)
                .where(SomeClass::foo, is(42))
        ));
```