### PR TITLE
Handling edge case of covariant return values for overridden methods …

### DIFF
--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
@@ -251,8 +251,8 @@ public abstract class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
       final Class<?> implClass = Class.forName(serializedLambda.getImplClass().replace('/', '.'));
       if (stream(implClass.getMethods())
           .noneMatch(m ->
-              m.getName().equals(serializedLambda.getImplMethodName()) &&
-              !m.isSynthetic())) {
+              m.getName().equals(serializedLambda.getImplMethodName())
+              && !m.isSynthetic())) {
         throw new IllegalArgumentException("The supplied lambda is not a direct method reference");
       }
     } catch (final ClassNotFoundException e) {

--- a/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
+++ b/pojo/src/main/java/com/spotify/hamcrest/pojo/IsPojo.java
@@ -20,6 +20,7 @@
 
 package com.spotify.hamcrest.pojo;
 
+import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 
 import com.google.auto.value.AutoValue;
@@ -246,28 +247,18 @@ public abstract class IsPojo<A> extends TypeSafeDiagnosingMatcher<A> {
   }
 
   private static void ensureDirectMethodReference(final SerializedLambda serializedLambda) {
-    final Method targetMethod;
     try {
       final Class<?> implClass = Class.forName(serializedLambda.getImplClass().replace('/', '.'));
-      targetMethod = findMethodByName(implClass, serializedLambda.getImplMethodName());
-    } catch (NoSuchMethodException | ClassNotFoundException e) {
-      throw new IllegalStateException(
-          "serializeLambda returned a SerializedLambda pointing to an invalid class/method", e);
-    }
-
-    if (targetMethod.isSynthetic()) {
-      throw new IllegalArgumentException("The supplied lambda is not a direct method reference");
-    }
-  }
-
-  private static Method findMethodByName(final Class<?> cls, final String methodName)
-      throws NoSuchMethodException {
-    for (final Method method : cls.getDeclaredMethods()) {
-      if (method.getName().equals(methodName)) {
-        return method;
+      if (stream(implClass.getMethods())
+          .noneMatch(m ->
+              m.getName().equals(serializedLambda.getImplMethodName()) &&
+              !m.isSynthetic())) {
+        throw new IllegalArgumentException("The supplied lambda is not a direct method reference");
       }
+    } catch (final ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "serializeLambda returned a SerializedLambda pointing to an invalid class", e);
     }
-    throw new NoSuchMethodException("No method " + methodName + " on " + cls);
   }
 
   @AutoValue

--- a/pojo/src/test/java/com/spotify/hamcrest/pojo/IsPojoTest.java
+++ b/pojo/src/test/java/com/spotify/hamcrest/pojo/IsPojoTest.java
@@ -24,6 +24,7 @@ import static com.spotify.hamcrest.pojo.IsPojo.pojo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
@@ -257,6 +258,14 @@ public class IsPojoTest {
   public void testMethodInSuperClass() throws Exception {
     final IsPojo<SomeClass> sut = pojo(SomeClass.class)
         .where("methodInParent", is(true));
+
+    assertThat(new SomeClass(), is(sut));
+  }
+
+  @Test
+  public void testCovariantMethodOverriding() {
+    final IsPojo<SomeClass> sut = pojo(SomeClass.class)
+        .where(SomeClass::covariantlyOverriddenMethod, hasSize(0));
 
     assertThat(new SomeClass(), is(sut));
   }

--- a/pojo/src/test/java/com/spotify/hamcrest/pojo/SomeClass.java
+++ b/pojo/src/test/java/com/spotify/hamcrest/pojo/SomeClass.java
@@ -20,6 +20,8 @@
 
 package com.spotify.hamcrest.pojo;
 
+import java.util.ArrayList;
+
 class SomeClass extends SomeParent {
 
   public int foo() {
@@ -40,5 +42,10 @@ class SomeClass extends SomeParent {
 
   public String throwsException() {
     throw new RuntimeException("Error!");
+  }
+
+  @Override
+  public ArrayList<String> covariantlyOverriddenMethod() {
+    return new ArrayList<>();
   }
 }

--- a/pojo/src/test/java/com/spotify/hamcrest/pojo/SomeParent.java
+++ b/pojo/src/test/java/com/spotify/hamcrest/pojo/SomeParent.java
@@ -20,8 +20,15 @@
 
 package com.spotify.hamcrest.pojo;
 
+import java.util.Collections;
+import java.util.List;
+
 class SomeParent {
   public boolean methodInParent() {
     return true;
+  }
+
+  public List<String> covariantlyOverriddenMethod() {
+    return Collections.emptyList();
   }
 }


### PR DESCRIPTION
…when preventing complex lambdas in .where(..., ...)

An example edge case:

```java
interface SomeInterface {
    List<String> getItems();
}

class SomeClass implements SomeInterface {
    ArrayList<String> items = new ArrayList<>();
    @Override
    ArrayList<String> getItems() { return items; }
}

class TestClass {
    // Will intermittently fail with IllegalArgumentException "The supplied lambda is not a direct method reference"
    @Test
    void testCase() {
        assertThat(
            getSomeClassInstanceSomehow(),
            is(pojo(SomeClass.class).where(SomeClass::getItems, hasSize(1))));
}
```

The problem is that `SomeClass.class.getMethods` will return an array that includes two `getItems` methods in an undefined order, one synthetic with `List` as return type and one non-synthetic with `ArrayList` as return type. The suggested change is to fail if there is no non-synthetic method with the given name instead of failing immediately if a synthetic method is encountered.