### PR TITLE
Use new hamcrest packaging

### DIFF
--- a/future/pom.xml
+++ b/future/pom.xml
@@ -12,7 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-junit</artifactId>
+      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-junit</artifactId>
+      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/optional/pom.xml
+++ b/optional/pom.xml
@@ -12,7 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-junit</artifactId>
+      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-junit</artifactId>
+      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,14 +81,14 @@
         <version>18.0</version>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>hamcrest-util</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-junit</artifactId>
-        <version>2.0.0.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -16,7 +16,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-junit</artifactId>
+      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
http://hamcrest.org/JavaHamcrest/distributables

this also means junit is not pulled transitively anymore (yeah!)
