### PR TITLE
Override project URL inherited from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>hamcrest</artifactId>
   <packaging>pom</packaging>
   <version>1.2.1-SNAPSHOT</version>
+  <url>https://github.com/spotify/java-hamcrest</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
com.spotify:foss-root is pointing to a project URL unrelated to this project