### PR TITLE
Allow future asserts to be interrupted.

### DIFF
--- a/future/src/main/java/com/spotify/hamcrest/future/ExceptionallyCompletedBlockingCompletionStage.java
+++ b/future/src/main/java/com/spotify/hamcrest/future/ExceptionallyCompletedBlockingCompletionStage.java
@@ -52,6 +52,7 @@ class ExceptionallyCompletedBlockingCompletionStage
           .appendValue(item);
       return false;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       mismatchDescription.appendText("a stage that was interrupted");
       return false;
     } catch (CancellationException e) {

--- a/future/src/main/java/com/spotify/hamcrest/future/SuccessfullyCompletedBlockingCompletionStage.java
+++ b/future/src/main/java/com/spotify/hamcrest/future/SuccessfullyCompletedBlockingCompletionStage.java
@@ -54,6 +54,7 @@ class SuccessfullyCompletedBlockingCompletionStage<T>
         return false;
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       mismatchDescription.appendText("a stage that was interrupted");
       return false;
     } catch (ExecutionException e) {

--- a/future/src/test/java/com/spotify/hamcrest/future/ExceptionallyCompletedBlockingCompletionStageTest.java
+++ b/future/src/test/java/com/spotify/hamcrest/future/ExceptionallyCompletedBlockingCompletionStageTest.java
@@ -25,10 +25,13 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.junit.Test;
@@ -83,6 +86,36 @@ public class ExceptionallyCompletedBlockingCompletionStageTest {
     } finally {
       // Clear the interrupted flag to avoid interference between tests
       Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void testInterruptActuallyInterruptsAssert() throws Exception {
+    final CountDownLatch beforeAssertLatch = new CountDownLatch(1);
+    final CountDownLatch afterAssertLatch = new CountDownLatch(1);
+    final Thread threadToInterrupt = new Thread(() -> {
+      try {
+        beforeAssertLatch.countDown();
+        assertThat(new CompletableFuture<String>(),
+            SUT);
+      } finally {
+        afterAssertLatch.countDown();
+      }
+    });
+    try {
+      threadToInterrupt.setDaemon(true);
+      threadToInterrupt.start();
+
+      beforeAssertLatch.await();
+      TimeUnit.SECONDS.sleep(1);
+      threadToInterrupt.interrupt();
+
+      assertTrue("Failed to interrupt assertion",
+          afterAssertLatch.await(2, TimeUnit.SECONDS));
+    } finally {
+      // Hamcrest goes into blocking method twice,
+      // second interrupt should release it and allow thread to finish:
+      threadToInterrupt.interrupt();
     }
   }
 }


### PR DESCRIPTION
Hamcrest enters matching method twice, first time to match value and second time to compose description.

When using JUnit5 `@Timeout` annotation or other ways to interrupt a thread, it will interrupt thread only once, so second entry will block on future indefinitely.

This PR restores thread interrupted state, so that second entry will not block and timeout could be effectively executed.

Possible issue: considering that we are working with futures, a state of non-complete future can change between matching value and matching description invocations. Saving state in the matcher has to be done on per-`future` basis to make matcher reusable between different future.