### PR TITLE
Add shortcut for present optionals with equalTo matcher

### DIFF
--- a/optional/src/main/java/com/spotify/hamcrest/optional/OptionalMatchers.java
+++ b/optional/src/main/java/com/spotify/hamcrest/optional/OptionalMatchers.java
@@ -21,6 +21,7 @@
 package com.spotify.hamcrest.optional;
 
 import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 import java.util.Optional;
 import org.hamcrest.Matcher;
@@ -42,6 +43,14 @@ public final class OptionalMatchers {
    */
   public static Matcher<Optional<?>> optionalWithValue() {
     return optionalWithValue(anything());
+  }
+
+  /**
+   * Creates a Matcher that matches if an Optional contains a given value
+   * as shortcut for optionalWithValue(equalTo(x)).
+   */
+  public static <T> Matcher<Optional<? extends T>> optionalWithValue(final T value) {
+    return optionalWithValue(equalTo(value));
   }
 
   /**

--- a/optional/src/test/java/com/spotify/hamcrest/optional/OptionalMatchersTest.java
+++ b/optional/src/test/java/com/spotify/hamcrest/optional/OptionalMatchersTest.java
@@ -39,6 +39,8 @@ public class OptionalMatchersTest {
   public void testPresent() {
     assertThat(Optional.of("x"), optionalWithValue());
 
+    assertThat(Optional.of("x"), OptionalMatchers.optionalWithValue("x"));
+
     assertThat(Optional.of("x"), OptionalMatchers.optionalWithValue(equalTo("x")));
     assertThat(Optional.of("x"), OptionalMatchers.optionalWithValue(not(equalTo("a"))));
 


### PR DESCRIPTION
We often use `optionalWithValue(equalTo(value))` in our tests. To simplify this Matcher it would be great to have a shortcut like the `is` Matcher of hamcrest-core provides, which automatically adds the `equalTo` if a value is supplied instead of a Matcher.